### PR TITLE
Make building the script not depend on PathFinder being installed at compile-time

### DIFF
--- a/Support.applescript
+++ b/Support.applescript
@@ -72,11 +72,14 @@ tell application "OmniFocus"
 		end repeat
 		
 		try
-			if application id "com.cocoatech.PathFinder" is running then
-				tell application id "com.cocoatech.PathFinder"
-					activate
-					open thePaths
-				end tell
+			if (my isRunning("com.cocoatech.PathFinder")) then
+				run script "
+					on run {thePaths}
+						tell application id \"com.cocoatech.PathFinder\" 
+							activate
+							open thePaths
+						end tell
+					end run" with parameters {thePaths}
 			else
 				tell application id "com.apple.finder"
 					repeat with aFolder in thePaths
@@ -150,3 +153,9 @@ on changePath(thePath)
 	set text item delimiters to ":"
 	return (thePath as text)
 end changePath
+
+on isRunning(bundleId)
+	tell application "System Events"
+		(bundle identifier of processes) contains bundleId
+	end tell
+end isRunning


### PR DESCRIPTION
When PathFinder is not installed at compile-time, the command `osacompile -o Support.scpt Support.applescript` returns an error because `osascript` seems to look for the app at compile-time.

This commit makes compiling the script independent from PathFinder being installed.

**Note:** Before merging, could someone who has PathFinder installed please double-check that the script still works, i.&nbsp;e. the folder still pops up in PathFinder?
Thanks a lot in advance!
